### PR TITLE
Optimise rating queries further

### DIFF
--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -1,7 +1,7 @@
 module GamesHelper
 
   def rated_check(game, user)
-    game.ratings.where(user_id: user).first.present? ? game.ratings.where(user_id: user).first.rating : "8"
+    current_user.ratings.find { |r| r.game_id == game.id } || "8"
   end
 
 end


### PR DESCRIPTION
Going further we only ever have to find the collection of ratings for a group of players and their games once in `PlayGroup`

Also reduced the number of `ActiveRecord` calls in the `rated_chech` helper to improve load times on games index page